### PR TITLE
Renamed Pilot-004 and Confidential Computing

### DIFF
--- a/content/resources.json
+++ b/content/resources.json
@@ -18,7 +18,7 @@
   ],
   "categories": [
     {
-      "title": "Pilot 004",
+      "title": "Data-to-Compute",
       "resources": [
         {
           "title": "📖 Easy Jump in Guide",
@@ -98,7 +98,7 @@
       ]
     },
     {
-      "title": "Confidential Computing",
+      "title": "CC",
       "resources": [
         {
           "title": "🎯 2nd Gaia-X Hackathon",


### PR DESCRIPTION
Renamed items so naming is more consistent:
* "Pilot 004" -> "Data-to-Compute ", because we also have "Compute-to-Data"
* "Confidential Computing" -> "CC", because we also have "EDC" and "SCS"